### PR TITLE
Added screen output flag to see the ros_info

### DIFF
--- a/launch/track_aruco_marker.launch
+++ b/launch/track_aruco_marker.launch
@@ -7,7 +7,7 @@
 
     <arg name="marker_size" doc="The size of the marker (in meters)" />
 
-    <node pkg="easy_aruco" type="easy_aruco_node" name="easy_aruco_node" >
+    <node pkg="easy_aruco" type="easy_aruco_node" name="easy_aruco_node" output="screen" >
         <param name="object_type" value="aruco_marker" />
 
         <param name="camera_namespace" value="$(arg camera_namespace)" />

--- a/launch/track_charuco_board.launch
+++ b/launch/track_charuco_board.launch
@@ -10,7 +10,7 @@
     <arg name="square_number_x" doc="The number of squares in the x direction" />
     <arg name="square_number_y" doc="The number of squares in the y direction" />
 
-    <node pkg="easy_aruco" type="easy_aruco_node" name="easy_aruco_node" >
+    <node pkg="easy_aruco" type="easy_aruco_node" name="easy_aruco_node" output="screen" >
         <param name="object_type" value="charuco_board" />
 
         <param name="camera_namespace" value="$(arg camera_namespace)" />


### PR DESCRIPTION
Hey Marco, while I was debugging to see the issues, I needed to print some ROS_INFO to the screen but since this option was not set, I was confused for a while, why nothing was working, so maybe it is better to add output="screen" to the node definitions in the launch files.